### PR TITLE
Fix `valid-apex-method-invocation` error when processing class with mixins

### DIFF
--- a/lib/rules/valid-apex-method-invocation.js
+++ b/lib/rules/valid-apex-method-invocation.js
@@ -24,8 +24,8 @@ module.exports = {
     },
 
     create(context) {
-        function isApexMethodReference(ref) {
-            const [def] = ref.defs;
+        function isApexMethodReference(variable) {
+            const [def] = variable.defs;
 
             return (
                 def &&
@@ -63,17 +63,19 @@ module.exports = {
                     messageId: 'invalidArgumentType',
                 });
             } else if (arg.type === 'Identifier') {
-                const argReference = scope.references.find((r) => r.identifier === arg).resolved;
+                const argReference = scope.references.find((r) => r.identifier === arg);
 
                 // Ignore unresolved or undefined arguments
-                if (!argReference || !argReference.defs.length) {
+                if (!argReference || !argReference.resolved) {
                     return;
                 }
 
                 // Report an error when the first argument is bound to a constant identifier initialized
                 // with an unsupported type.
-                const [argDefinition] = argReference.defs;
+                const argVariable = argReference.resolved;
+                const [argDefinition] = argVariable.defs;
                 if (
+                    argDefinition &&
                     argDefinition.type === 'Variable' &&
                     argDefinition.parent.kind === 'const' &&
                     argDefinition.node.init &&
@@ -97,12 +99,15 @@ module.exports = {
 
                 // Retrieve the callee reference from the current scope.
                 const scope = context.getScope();
-                const methodReference = scope.references.find((r) => r.identifier === callee)
-                    .resolved;
+                const methodReference = scope.references.find((r) => r.identifier === callee);
 
                 // Ignore the call expression if it can't be resolved from the current scope or if the
                 // call expression doesn't reference an Apex method.
-                if (!methodReference || !isApexMethodReference(methodReference)) {
+                if (
+                    !methodReference ||
+                    !methodReference.resolved ||
+                    !isApexMethodReference(methodReference.resolved)
+                ) {
                     return;
                 }
 

--- a/test/lib/rules/valid-apex-method-invocation.js
+++ b/test/lib/rules/valid-apex-method-invocation.js
@@ -37,6 +37,18 @@ ruleTester.run('valid-apex-method-invocation', rule, {
             `,
         },
         {
+            // Invocation with arguments passed as a literal from a nested scope.
+            code: `
+                import findContacts from '@salesforce/apex/ContactController.findContacts';
+
+                class provider {
+                    getData() {
+                        findContacts({ searchKey: 'Ted' });
+                    }
+                }
+            `,
+        },
+        {
             // Invocation on a continuation method with arguments passed as a literal.
             code: `
                 import findContacts from '@salesforce/apexContinuation/ContactController.findContacts';
@@ -88,7 +100,7 @@ ruleTester.run('valid-apex-method-invocation', rule, {
                 import findContacts from '@salesforce/apex/ContactController.findContacts';
 
                 function callApex(args) {
-                findContacts(args);
+                    findContacts(args);
                 }
             `,
         },
@@ -107,6 +119,21 @@ ruleTester.run('valid-apex-method-invocation', rule, {
                 findContacts('Ted');
             `,
         },
+        {
+            // Invocation of an unresolved function
+            code: `
+                findContacts('Ted');
+            `,
+        },
+        {
+            // [#4]: Fix regression related to the usage of Mixin
+            code: `
+                import { LightningElement } from 'lwc';
+                import { NavigationMixin } from 'lightning/navigation';
+                
+                export default class extends NavigationMixin(LightningElement) {}
+            `,
+        },
     ],
     invalid: [
         {
@@ -114,6 +141,23 @@ ruleTester.run('valid-apex-method-invocation', rule, {
             code: `
                 import findContacts from '@salesforce/apex/ContactController.findContacts';
                 findContacts('Ted');
+            `,
+            errors: [
+                {
+                    messageId: 'invalidArgumentType',
+                },
+            ],
+        },
+        {
+            // Invocation with string literal in a nested scope.
+            code: `
+                import findContacts from '@salesforce/apex/ContactController.findContacts';
+
+                class provider {
+                    getData() {
+                        findContacts('Ted');
+                    }
+                }
             `,
             errors: [
                 {


### PR DESCRIPTION
This PR adds extra guards to the scope resolution to prevent issues when the call expression identifier can't be resolved in the current scope.

Fixes #4.