### PR TITLE
docs: use correct repository URL

### DIFF
--- a/lib/utils/doc-url.js
+++ b/lib/utils/doc-url.js
@@ -9,9 +9,7 @@
 const { version, repository } = require('../../package.json');
 
 function docUrl(ruleName) {
-    // strip ".git" from end of URL
-    const base = repository.url.slice(0, -4);
-    return `${base}/blob/v${version}/docs/rules/${ruleName}.md`;
+    return `${repository.url}/blob/v${version}/docs/rules/${ruleName}.md`;
 }
 
 module.exports = {


### PR DESCRIPTION
Code assumes repo URL has `.git`, but it doesn't.

Fixes #16.